### PR TITLE
Update next.config.ts to allow remote images and enhance BannerSpot component with logo display

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/components/spots/banner-spot.tsx
+++ b/src/components/spots/banner-spot.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import spotsConfig from '@/config/spots.json';
 import Link from 'next/link';
 import { buttonVariants } from '@/components/ui/button';
+import Image from 'next/image';
 
 interface BannerSpotProps {
   id: string;
@@ -32,7 +33,10 @@ export function BannerSpot({ id, className }: BannerSpotProps) {
         <div className="flex items-center gap-2">
           <span className="text-xs text-[#71767b]">Ad</span>
           <span className="text-[#1d9bf0]">•</span>
-          <span>{!spot.available ? spot.data.title : 'Want to be our sponsor?'}</span>
+          {spot.logo && <Image src={spot.logo} alt={spot.data.title} width={24} height={24} />}
+          <span className="font-bold">
+            {!spot.available ? spot.data.title : 'Want to be our sponsor?'}
+          </span>
           <span className="text-[#1d9bf0]">–</span>
           <span>
             {!spot.available

--- a/src/config/spots.json
+++ b/src/config/spots.json
@@ -8,10 +8,11 @@
       "endDate": "2024-05-19",
       "available": false,
       "stripeUrl": "https://buy.stripe.com/dR6cNS3C569v1rOaEH",
+      "logo": "https://www.synapt.app/logo.png",
       "data": {
-        "title": "Themeptation",
-        "description": "Landing page & templates for Startups and SaaS",
-        "url": "https://www.themeptation.net"
+        "title": "Synapt",
+        "description": "Get 3x more engagement while spending 70% less time on social media",
+        "url": "https://www.synapt.app?ref=postroast"
       }
     },
     {


### PR DESCRIPTION
- Configured next.config.ts to support remote images from any hostname.
- Updated BannerSpot component to conditionally render a logo image if available, improving visual representation of sponsors.
- Modified spots.json to include a logo URL for the Synapt entry, aligning with the new display feature.